### PR TITLE
Add Postgres ApiDB.Indel table

### DIFF
--- a/Main/bin/installApidbSchema
+++ b/Main/bin/installApidbSchema
@@ -142,6 +142,7 @@ my @create = qw(
   createWGCNAModuleEigengeneResults.sql
   createNAFeatureMetaCycle.sql
   createCNVTables.sql
+  createIndel.sql
   createRflpTables.sql
   createNAFeatureImage.sql
   createSequenceTaxon.sql

--- a/Main/lib/sql/apidbschema/Postgres/createIndel.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createIndel.sql
@@ -1,0 +1,48 @@
+CREATE TABLE ApiDB.Indel (
+  INDEL_ID                      NUMERIC(12)    NOT NULL,
+  PROTOCOL_APP_NODE_ID          NUMERIC(10)    NOT NULL,
+  NA_SEQUENCE_ID                NUMERIC(12)    NOT NULL,
+  LOCATION                      NUMERIC(15)    NOT NULL,
+  SHIFT                         NUMERIC(5)     NOT NULL,
+  MODIFICATION_DATE             TIMESTAMP,
+  USER_READ                     NUMERIC(1),
+  USER_WRITE                    NUMERIC(1),
+  GROUP_READ                    NUMERIC(1),
+  GROUP_WRITE                   NUMERIC(1),
+  OTHER_READ                    NUMERIC(1),
+  OTHER_WRITE                   NUMERIC(1),
+  ROW_USER_ID                   NUMERIC(12),
+  ROW_GROUP_ID                  NUMERIC(3),
+  ROW_PROJECT_ID                NUMERIC(4),
+  ROW_ALG_INVOCATION_ID         NUMERIC(12),
+  PRIMARY KEY (INDEL_ID),
+  FOREIGN KEY (PROTOCOL_APP_NODE_ID) REFERENCES Study.ProtocolAppNode (PROTOCOL_APP_NODE_ID),
+  FOREIGN KEY (NA_SEQUENCE_ID) REFERENCES DoTS.NASequenceImp (NA_SEQUENCE_ID)
+);
+
+CREATE INDEX indel_ix0 ON apidb.Indel (na_sequence_id, indel_id);
+CREATE INDEX indel_ix1 ON apidb.Indel (protocol_app_node_id, indel_id);
+
+CREATE SEQUENCE ApiDB.Indel_sq;
+
+GRANT SELECT ON ApiDB.Indel TO gus_r;
+GRANT INSERT, SELECT, UPDATE, DELETE ON ApiDB.Indel TO gus_w;
+
+GRANT SELECT ON ApiDB.Indel_sq TO gus_r;
+GRANT SELECT ON ApiDB.Indel_sq TO gus_w;
+
+INSERT INTO core.TableInfo
+    (table_id, name, table_type, primary_key_column, database_id, is_versioned,
+     is_view, view_on_table_id, superclass_table_id, is_updatable,
+     modification_date, user_read, user_write, group_read, group_write,
+     other_read, other_write, row_user_id, row_group_id, row_project_id,
+     row_alg_invocation_id)
+SELECT NEXTVAL('core.tableinfo_sq'), 'Indel',
+       'Standard', 'INDEL_ID',
+       d.database_id, 0, 0, NULL, NULL, 1, localtimestamp, 1, 1, 1, 1, 1, 1, 1, 1,
+       p.project_id, 0
+FROM
+     (SELECT MAX(project_id) AS project_id FROM core.ProjectInfo) p,
+     (SELECT database_id FROM core.DatabaseInfo WHERE name = 'ApiDB') d
+WHERE 'Indel' NOT IN (SELECT name FROM core.TableInfo
+                                    WHERE database_id = d.database_id);


### PR DESCRIPTION
## Summary
- Ports the Oracle-only `ApiDB.Indel` table to Postgres (`Main/lib/sql/apidbschema/Postgres/createIndel.sql`), registered in `installApidbSchema` right after `createCNVTables.sql`.
- Replaces the old `sample_name` (free text) and `external_database_release_id` columns with a single `protocol_app_node_id` FK to `Study.ProtocolAppNode`, matching the `ChrCopyNumber`/`GeneCopyNumber` pattern.
- Adds `na_sequence_id`/`protocol_app_node_id` indexes (Oracle version had none) for consistency with those two tables.
- This unblocks loading DNASeq indel results (`*_indels.tsv` from `dnaseq-nextflow`) through the generic `InsertStudyResults` plugin instead of the old dedicated `InsertIndel` plugin, which will be removed in a follow-up.

## Test plan
- [ ] Run `installApidbSchema` against a scratch Postgres DB and confirm `apidb.indel` is created with the expected columns/FKs/indexes.
- [ ] Confirm `core.tableinfo` gets an `Indel` row.
- [x] Follow-up PR: update `InsertStudyResults` to handle the `Indel` protocol and remove `InsertIndel.pm` / `WorkflowSteps::InsertIndels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)