### PR TITLE
Add ApiDB variation load tables (Postgres)

### DIFF
--- a/Main/bin/installApidbSchema
+++ b/Main/bin/installApidbSchema
@@ -93,6 +93,7 @@ my @create = qw(
   createAnalysisMethodInvocation.sql
   createDatasource.sql
   createSnpTables.sql
+  createVariationTables.sql
   createGeneInteractionTables.sql
   createGeneFeatureProduct.sql
   createGeneFeatureName.sql

--- a/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
@@ -4,6 +4,7 @@ CREATE TABLE ApiDB.VariationFeature (
   reference_strain                VARCHAR(100)  NOT NULL,
   is_coding                       NUMERIC(1)    NOT NULL,
   variant_type                    VARCHAR(10)   NOT NULL,
+  source_id                       VARCHAR(100)  NOT NULL,
   distinct_strain_count           NUMERIC(6),
   called_strain_count             NUMERIC(6),
   no_call_strain_count            NUMERIC(6),

--- a/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
@@ -5,7 +5,6 @@ CREATE TABLE ApiDB.VariationFeature (
   reference_strain                VARCHAR(100)  NOT NULL,
   is_coding                       NUMERIC(1)    NOT NULL,
   variant_type                    VARCHAR(10)   NOT NULL,
-  source_id                       VARCHAR(100)  NOT NULL,
   distinct_strain_count           NUMERIC(6),
   called_strain_count             NUMERIC(6),
   no_call_strain_count            NUMERIC(6),

--- a/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
@@ -1,4 +1,5 @@
 CREATE TABLE ApiDB.VariationFeature (
+  source_id                       VARCHAR(100)  NOT NULL,
   sequence_source_id              VARCHAR(60)   NOT NULL,
   location                        NUMERIC(12)   NOT NULL,
   reference_strain                VARCHAR(100)  NOT NULL,
@@ -33,7 +34,8 @@ CREATE TABLE ApiDB.VariationFeature (
   external_database_release_id    NUMERIC(10)   NOT NULL,
   FOREIGN KEY (external_database_release_id)
     REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
-  PRIMARY KEY (sequence_source_id, location)
+  PRIMARY KEY (sequence_source_id, location),
+  UNIQUE (source_id)
 );
 
 GRANT insert, select, update, delete ON ApiDB.VariationFeature TO gus_w;
@@ -52,7 +54,6 @@ CREATE TABLE ApiDB.VariationTranscriptProduct (
   product                             VARCHAR(1),
   matches_ref_codon                   NUMERIC(1),
   matches_ref_product                 NUMERIC(1),
-  downstream_of_frameshift_strain_ids VARCHAR(4000),
   hgvs_p                              VARCHAR(500),
   FOREIGN KEY (sequence_source_id, location)
     REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,

--- a/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
@@ -1,0 +1,99 @@
+CREATE TABLE ApiDB.VariationFeature (
+  sequence_source_id              VARCHAR(60)   NOT NULL,
+  location                        NUMERIC(12)   NOT NULL,
+  reference_strain                VARCHAR(100)  NOT NULL,
+  is_coding                       NUMERIC(1)    NOT NULL,
+  variant_type                    VARCHAR(10)   NOT NULL,
+  distinct_strain_count           NUMERIC(6),
+  called_strain_count             NUMERIC(6),
+  no_call_strain_count            NUMERIC(6),
+  call_rate                       FLOAT,
+  total_ploidy_count              NUMERIC(8),
+  ref_allele_frequency            FLOAT,
+  het_strain_count                NUMERIC(6),
+  snp_ref_allele                  VARCHAR(1),
+  snp_major_allele                VARCHAR(1),
+  snp_major_allele_frequency      FLOAT,
+  snp_major_allele_strain_count   NUMERIC(6),
+  snp_minor_allele                VARCHAR(1),
+  snp_minor_allele_frequency      FLOAT,
+  snp_minor_allele_strain_count   NUMERIC(6),
+  snp_major_genomic_hgvs          VARCHAR(500),
+  snp_minor_genomic_hgvs          VARCHAR(500),
+  indel_ref_allele                VARCHAR(1000),
+  indel_major_allele              VARCHAR(1000),
+  indel_major_allele_frequency    FLOAT,
+  indel_major_allele_strain_count NUMERIC(6),
+  indel_minor_allele              VARCHAR(1000),
+  indel_minor_allele_frequency    FLOAT,
+  indel_minor_allele_strain_count NUMERIC(6),
+  indel_major_genomic_hgvs        VARCHAR(500),
+  indel_minor_genomic_hgvs        VARCHAR(500),
+  indel_frame_effect              VARCHAR(20),
+  external_database_release_id    NUMERIC(10)   NOT NULL,
+  FOREIGN KEY (external_database_release_id)
+    REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
+  PRIMARY KEY (sequence_source_id, location)
+);
+
+GRANT insert, select, update, delete ON ApiDB.VariationFeature TO gus_w;
+GRANT select ON ApiDB.VariationFeature TO gus_r;
+
+
+CREATE TABLE ApiDB.VariationTranscriptProduct (
+  sequence_source_id                  VARCHAR(60)   NOT NULL,
+  location                            NUMERIC(12)   NOT NULL,
+  na_feature_id                       NUMERIC(10)   NOT NULL,
+  pos_in_cds                          NUMERIC(12),
+  pos_in_protein                      NUMERIC(12),
+  codon                               VARCHAR(3),
+  pos_in_codon                        NUMERIC(1),
+  strain_count                        NUMERIC(6),
+  product                             VARCHAR(1),
+  matches_ref_codon                   NUMERIC(1),
+  matches_ref_product                 NUMERIC(1),
+  downstream_of_frameshift_strain_ids VARCHAR(4000),
+  hgvs_p                              VARCHAR(500),
+  FOREIGN KEY (sequence_source_id, location)
+    REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
+  FOREIGN KEY (na_feature_id)
+    REFERENCES dots.NaFeatureImp (na_feature_id)
+);
+
+GRANT insert, select, update, delete ON ApiDB.VariationTranscriptProduct TO gus_w;
+GRANT select ON ApiDB.VariationTranscriptProduct TO gus_r;
+
+
+CREATE TABLE ApiDB.VariationEffect (
+  sequence_source_id   VARCHAR(60)   NOT NULL,
+  location             NUMERIC(12)   NOT NULL,
+  allele               VARCHAR(1000),
+  na_feature_id        NUMERIC(10),
+  impact               VARCHAR(20),
+  effect               VARCHAR(60),
+  hgvs_c               VARCHAR(500),
+  source               VARCHAR(20),
+  FOREIGN KEY (sequence_source_id, location)
+    REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
+  FOREIGN KEY (na_feature_id)
+    REFERENCES dots.NaFeatureImp (na_feature_id)
+);
+
+GRANT insert, select, update, delete ON ApiDB.VariationEffect TO gus_w;
+GRANT select ON ApiDB.VariationEffect TO gus_r;
+
+
+-- Indexes: Postgres auto-indexes PKs/unique constraints but NOT foreign-key
+-- columns. Index the child->parent composite FK and the na_feature_id FK
+-- (speeds FK checks and per-transcript / per-locus queries), plus the parent's
+-- external_database_release_id (used by reload deletes).
+CREATE INDEX variationtranscriptproduct_loc_ix
+  ON ApiDB.VariationTranscriptProduct (sequence_source_id, location);
+CREATE INDEX variationtranscriptproduct_naf_ix
+  ON ApiDB.VariationTranscriptProduct (na_feature_id);
+CREATE INDEX variationeffect_loc_ix
+  ON ApiDB.VariationEffect (sequence_source_id, location);
+CREATE INDEX variationeffect_naf_ix
+  ON ApiDB.VariationEffect (na_feature_id);
+CREATE INDEX variationfeature_extdbrls_ix
+  ON ApiDB.VariationFeature (external_database_release_id);

--- a/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
@@ -1,3 +1,5 @@
+---------ApiDB.VariationFeature ----------------------------
+------------------------------------------------------------
 CREATE TABLE ApiDB.VariationFeature (
   source_id                       VARCHAR(100)  NOT NULL,
   sequence_source_id              VARCHAR(60)   NOT NULL,
@@ -32,15 +34,18 @@ CREATE TABLE ApiDB.VariationFeature (
   indel_minor_genomic_hgvs        VARCHAR(500),
   indel_frame_effect              VARCHAR(20),
   external_database_release_id    NUMERIC(10)   NOT NULL,
-  FOREIGN KEY (external_database_release_id)
-    REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
   PRIMARY KEY (sequence_source_id, location),
+  FOREIGN KEY (external_database_release_id) REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
   UNIQUE (source_id)
 );
 
-GRANT insert, select, update, delete ON ApiDB.VariationFeature TO gus_w;
-GRANT select ON ApiDB.VariationFeature TO gus_r;
+GRANT SELECT ON ApiDB.VariationFeature TO gus_r;
+GRANT INSERT, UPDATE, DELETE ON ApiDB.VariationFeature TO gus_w;
 
+CREATE INDEX variationfeature_extdbrls_ix ON ApiDB.VariationFeature (external_database_release_id);
+
+---------ApiDB.VariationTranscriptProduct ------------------
+------------------------------------------------------------
 
 CREATE TABLE ApiDB.VariationTranscriptProduct (
   sequence_source_id                  VARCHAR(60)   NOT NULL,
@@ -55,15 +60,18 @@ CREATE TABLE ApiDB.VariationTranscriptProduct (
   matches_ref_codon                   NUMERIC(1),
   matches_ref_product                 NUMERIC(1),
   hgvs_p                              VARCHAR(500),
-  FOREIGN KEY (sequence_source_id, location)
-    REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
-  FOREIGN KEY (na_feature_id)
-    REFERENCES dots.NaFeatureImp (na_feature_id)
+  FOREIGN KEY (sequence_source_id, location) REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
+  FOREIGN KEY (na_feature_id) REFERENCES dots.NaFeatureImp (na_feature_id)
 );
 
-GRANT insert, select, update, delete ON ApiDB.VariationTranscriptProduct TO gus_w;
-GRANT select ON ApiDB.VariationTranscriptProduct TO gus_r;
+GRANT SELECT ON ApiDB.VariationTranscriptProduct TO gus_r;
+GRANT INSERT, UPDATE, DELETE ON ApiDB.VariationTranscriptProduct TO gus_w;
 
+CREATE INDEX variationtranscriptproduct_loc_ix ON ApiDB.VariationTranscriptProduct (sequence_source_id, location);
+CREATE INDEX variationtranscriptproduct_naf_ix ON ApiDB.VariationTranscriptProduct (na_feature_id);
+
+---------ApiDB.VariationEffect -----------------------------
+------------------------------------------------------------
 
 CREATE TABLE ApiDB.VariationEffect (
   sequence_source_id   VARCHAR(60)   NOT NULL,
@@ -74,27 +82,14 @@ CREATE TABLE ApiDB.VariationEffect (
   effect               VARCHAR(60),
   hgvs_c               VARCHAR(500),
   source               VARCHAR(20),
-  FOREIGN KEY (sequence_source_id, location)
-    REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
-  FOREIGN KEY (na_feature_id)
-    REFERENCES dots.NaFeatureImp (na_feature_id)
+  FOREIGN KEY (sequence_source_id, location) REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
+  FOREIGN KEY (na_feature_id) REFERENCES dots.NaFeatureImp (na_feature_id)
 );
 
-GRANT insert, select, update, delete ON ApiDB.VariationEffect TO gus_w;
-GRANT select ON ApiDB.VariationEffect TO gus_r;
+GRANT SELECT ON ApiDB.VariationEffect TO gus_r;
+GRANT INSERT, UPDATE, DELETE ON ApiDB.VariationEffect TO gus_w;
 
 
--- Indexes: Postgres auto-indexes PKs/unique constraints but NOT foreign-key
--- columns. Index the child->parent composite FK and the na_feature_id FK
--- (speeds FK checks and per-transcript / per-locus queries), plus the parent's
--- external_database_release_id (used by reload deletes).
-CREATE INDEX variationtranscriptproduct_loc_ix
-  ON ApiDB.VariationTranscriptProduct (sequence_source_id, location);
-CREATE INDEX variationtranscriptproduct_naf_ix
-  ON ApiDB.VariationTranscriptProduct (na_feature_id);
-CREATE INDEX variationeffect_loc_ix
-  ON ApiDB.VariationEffect (sequence_source_id, location);
-CREATE INDEX variationeffect_naf_ix
-  ON ApiDB.VariationEffect (na_feature_id);
-CREATE INDEX variationfeature_extdbrls_ix
-  ON ApiDB.VariationFeature (external_database_release_id);
+CREATE INDEX variationeffect_loc_ix ON ApiDB.VariationEffect (sequence_source_id, location);
+CREATE INDEX variationeffect_naf_ix ON ApiDB.VariationEffect (na_feature_id);
+

--- a/Main/lib/sql/apidbschema/Postgres/dropVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/dropVariationTables.sql
@@ -1,0 +1,3 @@
+DROP TABLE ApiDB.VariationEffect;
+DROP TABLE ApiDB.VariationTranscriptProduct;
+DROP TABLE ApiDB.VariationFeature;


### PR DESCRIPTION
## Summary

Adds three Postgres tables to land the variation `.dat` files produced by the `dnaseq-nextflow` `mergeExperiments` workflow, plus installer wiring and a parallel drop script.

- **`ApiDB.VariationFeature`** — one row per locus (parent). Natural composite PK `(sequence_source_id, location)`.
- **`ApiDB.VariationTranscriptProduct`** — per-transcript codon/product detail.
- **`ApiDB.VariationEffect`** — SnpEff / product-call functional effects.

### Design choices
- **No GUS housekeeping columns and no `core.TableInfo` registration** — deliberately following the legacy SNP-table precedent. These are high-volume tables loaded by a bespoke bulk `\copy` loader (not the GUS plugin), where plugin overhead is prohibitively slow. A composite natural PK also has no single `primary_key_column` to register.
- Child tables FK to the parent's composite key with **`ON DELETE CASCADE`**, so a dataset reload is a single `DELETE FROM ApiDB.VariationFeature WHERE external_database_release_id = X`.
- `na_feature_id` → `dots.NaFeatureImp` (transcript source-ids resolve 1:1 via `dots.Transcript.source_id`; `na_feature_id` NULLable in `VariationEffect` for intergenic rows).
- `external_database_release_id` on the parent only → `sres.ExternalDatabaseRelease`.
- FK-supporting indexes added (Postgres does not auto-index FK columns).

### Verification
DDL run against `unidb_shu_a` inside a rolled-back transaction — parses cleanly, all types accepted, and both FK sets resolve against the live `dots.nafeatureimp` / `sres.externaldatabaserelease`. Nothing persisted.

### Notes
- **Postgres only.** The `@create` list in `installApidbSchema` is platform-shared, so an Oracle install would fail on a missing `Oracle/createVariationTables.sql` twin until one is added. Acceptable while Oracle installs are retired.
- The bulk `\copy` loader is out of scope for this PR (schema only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)