### PR TITLE
Add apidb.GeneCoexpression table (Postgres)

### DIFF
--- a/Main/bin/installApidbSchema
+++ b/Main/bin/installApidbSchema
@@ -96,6 +96,7 @@ my @create = qw(
   createGeneInteractionTables.sql
   createGeneFeatureProduct.sql
   createGeneFeatureName.sql
+  createGeneCoexpression.sql
   createOrthologGroup.sql
   createECTables.sql
   createGroupMapping.sql

--- a/Main/lib/sql/apidbschema/Postgres/createGeneCoexpression.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createGeneCoexpression.sql
@@ -1,8 +1,7 @@
 CREATE SEQUENCE ApiDB.GeneCoexpression_sq;
 
-GRANT select ON ApiDB.GeneCoexpression_sq TO gus_r;
-GRANT select ON ApiDB.GeneCoexpression_sq TO gus_w;
-
+GRANT SELECT ON ApiDB.GeneCoexpression_sq TO gus_r;
+GRANT SELECT ON ApiDB.GeneCoexpression_sq TO gus_w;
 
 CREATE TABLE ApiDB.GeneCoexpression (
   gene_coexpression_id           NUMERIC(10)   NOT NULL  DEFAULT nextval('apidb.GeneCoexpression_sq'),
@@ -10,21 +9,16 @@ CREATE TABLE ApiDB.GeneCoexpression (
   associated_gene_id             VARCHAR(50)   NOT NULL,
   coefficient                    FLOAT8,
   external_database_release_id   NUMERIC(10)   NOT NULL,
-  FOREIGN KEY (external_database_release_id)
-    REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
-  PRIMARY KEY (gene_coexpression_id)
+  PRIMARY KEY (gene_coexpression_id),
+  FOREIGN KEY (external_database_release_id) REFERENCES sres.ExternalDatabaseRelease (external_database_release_id)
 );
 
-GRANT insert, select, update, delete ON ApiDB.GeneCoexpression TO gus_w;
-GRANT select ON ApiDB.GeneCoexpression TO gus_r;
-
+GRANT SELECT ON ApiDB.GeneCoexpression TO gus_r;
+GRANT INSERT, UPDATE, DELETE ON ApiDB.GeneCoexpression TO gus_w;
 
 -- Indexes: the PK auto-indexes gene_coexpression_id. Index gene_id (per-gene
 -- coexpression lookups), associated_gene_id (reverse lookups), and
 -- external_database_release_id (used by reload deletes).
-CREATE INDEX genecoexpression_gene_ix
-  ON ApiDB.GeneCoexpression (gene_id);
-CREATE INDEX genecoexpression_assoc_gene_ix
-  ON ApiDB.GeneCoexpression (associated_gene_id);
-CREATE INDEX genecoexpression_extdbrls_ix
-  ON ApiDB.GeneCoexpression (external_database_release_id);
+CREATE INDEX genecoexpression_gene_ix ON ApiDB.GeneCoexpression (gene_id);
+CREATE INDEX genecoexpression_assoc_gene_ix ON ApiDB.GeneCoexpression (associated_gene_id);
+CREATE INDEX genecoexpression_extdbrls_ix ON ApiDB.GeneCoexpression (external_database_release_id);

--- a/Main/lib/sql/apidbschema/Postgres/createGeneCoexpression.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createGeneCoexpression.sql
@@ -4,7 +4,7 @@ GRANT SELECT ON ApiDB.GeneCoexpression_sq TO gus_r;
 GRANT SELECT ON ApiDB.GeneCoexpression_sq TO gus_w;
 
 CREATE TABLE ApiDB.GeneCoexpression (
-  gene_coexpression_id           NUMERIC(10)   NOT NULL  DEFAULT nextval('apidb.GeneCoexpression_sq'),
+  gene_coexpression_id           NUMERIC(10)   NOT NULL  DEFAULT nextval('apidb.genecoexpression_sq'),
   gene_id                        VARCHAR(50)   NOT NULL,
   associated_gene_id             VARCHAR(50)   NOT NULL,
   coefficient                    FLOAT8,

--- a/Main/lib/sql/apidbschema/Postgres/createGeneCoexpression.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createGeneCoexpression.sql
@@ -1,0 +1,30 @@
+CREATE SEQUENCE ApiDB.GeneCoexpression_sq;
+
+GRANT select ON ApiDB.GeneCoexpression_sq TO gus_r;
+GRANT select ON ApiDB.GeneCoexpression_sq TO gus_w;
+
+
+CREATE TABLE ApiDB.GeneCoexpression (
+  gene_coexpression_id           NUMERIC(10)   NOT NULL  DEFAULT nextval('apidb.GeneCoexpression_sq'),
+  gene_id                        VARCHAR(50)   NOT NULL,
+  associated_gene_id             VARCHAR(50)   NOT NULL,
+  coefficient                    FLOAT8,
+  external_database_release_id   NUMERIC(10)   NOT NULL,
+  FOREIGN KEY (external_database_release_id)
+    REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
+  PRIMARY KEY (gene_coexpression_id)
+);
+
+GRANT insert, select, update, delete ON ApiDB.GeneCoexpression TO gus_w;
+GRANT select ON ApiDB.GeneCoexpression TO gus_r;
+
+
+-- Indexes: the PK auto-indexes gene_coexpression_id. Index gene_id (per-gene
+-- coexpression lookups), associated_gene_id (reverse lookups), and
+-- external_database_release_id (used by reload deletes).
+CREATE INDEX genecoexpression_gene_ix
+  ON ApiDB.GeneCoexpression (gene_id);
+CREATE INDEX genecoexpression_assoc_gene_ix
+  ON ApiDB.GeneCoexpression (associated_gene_id);
+CREATE INDEX genecoexpression_extdbrls_ix
+  ON ApiDB.GeneCoexpression (external_database_release_id);

--- a/Main/lib/sql/apidbschema/Postgres/dropGeneCoexpression.sql
+++ b/Main/lib/sql/apidbschema/Postgres/dropGeneCoexpression.sql
@@ -1,0 +1,2 @@
+DROP TABLE ApiDB.GeneCoexpression;
+DROP SEQUENCE ApiDB.GeneCoexpression_sq;


### PR DESCRIPTION
## Summary
Adds a new Postgres table `apidb.GeneCoexpression` for gene coexpression pairs, ported from the Oracle definition.

Follows the `dnaseq-tables` (`VariationFeature`) convention for housekeeping-free load tables: no GUS housekeeping columns, no `core.TableInfo` registration.

## Table
| Column | Type | Notes |
|--------|------|-------|
| `gene_coexpression_id` | `NUMERIC(10) NOT NULL` | PK; `DEFAULT nextval('apidb.GeneCoexpression_sq')` |
| `gene_id` | `VARCHAR(50) NOT NULL` | |
| `associated_gene_id` | `VARCHAR(50) NOT NULL` | |
| `coefficient` | `FLOAT8` | Oracle `FLOAT(126)` → double precision |
| `external_database_release_id` | `NUMERIC(10) NOT NULL` | FK → `sres.ExternalDatabaseRelease` |

## Loading
Designed for `psql COPY`. The sequence is created before the table so the column `DEFAULT` resolves, letting a column-list COPY assign ids automatically:

```sql
COPY apidb.GeneCoexpression (gene_id, associated_gene_id, coefficient, external_database_release_id)
  FROM '...' WITH (FORMAT csv);
```

## Changes
- `Postgres/createGeneCoexpression.sql` — sequence, table, grants, indexes
- `Postgres/dropGeneCoexpression.sql` — manual-reverse drop (table + sequence)
- `bin/installApidbSchema` — registered in `@create` list

## Notes
- Postgres-only; no Oracle counterpart written (per request).
- Indexes on `gene_id`, `associated_gene_id`, and `external_database_release_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)