### PR TITLE
Add Postgres FileAttributes create/drop scripts

### DIFF
--- a/Main/bin/installApidbSchema
+++ b/Main/bin/installApidbSchema
@@ -171,6 +171,7 @@ my @create = qw(
   createAntiSmashTables.sql
   createGenePhenotype.sql
   createNAFeatureList.sql
+  createFileAttributes.sql
 );
 
 my @delete = qw(

--- a/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
@@ -12,5 +12,5 @@ CREATE TABLE apidb.FileAttributes (
   PRIMARY KEY (file_id)
 );
 
-GRANT select ON apidb.FileAttributes TO gus_r;
-GRANT insert, update, delete ON apidb.FileAttributes TO gus_w;
+GRANT SELECT ON apidb.FileAttributes TO gus_r;
+GRANT INSERT, UPDATE, DELETE ON apidb.FileAttributes TO gus_w;

--- a/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
@@ -14,20 +14,3 @@ CREATE TABLE apidb.FileAttributes (
 
 GRANT select ON apidb.FileAttributes TO gus_r;
 GRANT insert, update, delete ON apidb.FileAttributes TO gus_w;
-
-
-INSERT INTO core.TableInfo
-    (table_id, name, table_type, primary_key_column, database_id, is_versioned,
-     is_view, view_on_table_id, superclass_table_id, is_updatable,
-     modification_date, user_read, user_write, group_read, group_write,
-     other_read, other_write, row_user_id, row_group_id, row_project_id,
-     row_alg_invocation_id)
-SELECT NEXTVAL('core.tableinfo_sq'), 'FileAttributes',
-       'Standard', 'file_id',
-       d.database_id, 0, 0, NULL, NULL, 1, localtimestamp, 1, 1, 1, 1, 1, 1, 1, 1,
-       p.project_id, 0
-FROM
-     (SELECT MAX(project_id) AS project_id FROM core.ProjectInfo) p,
-     (SELECT database_id FROM core.DatabaseInfo WHERE lower(name) = 'apidb') d
-WHERE 'fileattributes' NOT IN (SELECT lower(name) FROM core.TableInfo
-                                    WHERE database_id = d.database_id);

--- a/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
@@ -12,11 +12,8 @@ CREATE TABLE apidb.FileAttributes (
   PRIMARY KEY (file_id)
 );
 
-
-GRANT insert, select, update, delete ON apidb.FileAttributes TO gus_w;
 GRANT select ON apidb.FileAttributes TO gus_r;
-GRANT select ON apidb.FileAttributes TO gus_w;
-
+GRANT insert, update, delete ON apidb.FileAttributes TO gus_w;
 
 
 INSERT INTO core.TableInfo

--- a/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createFileAttributes.sql
@@ -1,0 +1,36 @@
+CREATE TABLE apidb.FileAttributes (
+  file_id     varchar(100),
+  filename    varchar(200),
+  filepath    varchar(250),
+  organism    varchar(100),
+  build_num   numeric(3),
+  category    varchar(50),
+  file_type   varchar(50),
+  file_format varchar(20),
+  filesize    numeric(10),
+  checksum    varchar(100),
+  PRIMARY KEY (file_id)
+);
+
+
+GRANT insert, select, update, delete ON apidb.FileAttributes TO gus_w;
+GRANT select ON apidb.FileAttributes TO gus_r;
+GRANT select ON apidb.FileAttributes TO gus_w;
+
+
+
+INSERT INTO core.TableInfo
+    (table_id, name, table_type, primary_key_column, database_id, is_versioned,
+     is_view, view_on_table_id, superclass_table_id, is_updatable,
+     modification_date, user_read, user_write, group_read, group_write,
+     other_read, other_write, row_user_id, row_group_id, row_project_id,
+     row_alg_invocation_id)
+SELECT NEXTVAL('core.tableinfo_sq'), 'FileAttributes',
+       'Standard', 'file_id',
+       d.database_id, 0, 0, NULL, NULL, 1, localtimestamp, 1, 1, 1, 1, 1, 1, 1, 1,
+       p.project_id, 0
+FROM
+     (SELECT MAX(project_id) AS project_id FROM core.ProjectInfo) p,
+     (SELECT database_id FROM core.DatabaseInfo WHERE lower(name) = 'apidb') d
+WHERE 'fileattributes' NOT IN (SELECT lower(name) FROM core.TableInfo
+                                    WHERE database_id = d.database_id);

--- a/Main/lib/sql/apidbschema/Postgres/dropFileAttributes.sql
+++ b/Main/lib/sql/apidbschema/Postgres/dropFileAttributes.sql
@@ -1,0 +1,7 @@
+DROP TABLE apidb.FileAttributes;
+
+DELETE FROM core.TableInfo
+WHERE lower(name) = lower('FileAttributes')
+  AND database_id = (SELECT database_id
+                     FROM core.DatabaseInfo
+                     WHERE lower(name) = 'apidb');

--- a/Main/lib/sql/apidbschema/Postgres/dropFileAttributes.sql
+++ b/Main/lib/sql/apidbschema/Postgres/dropFileAttributes.sql
@@ -1,7 +1,1 @@
 DROP TABLE apidb.FileAttributes;
-
-DELETE FROM core.TableInfo
-WHERE lower(name) = lower('FileAttributes')
-  AND database_id = (SELECT database_id
-                     FROM core.DatabaseInfo
-                     WHERE lower(name) = 'apidb');


### PR DESCRIPTION
Adds apidb.FileAttributes for Postgres, populated by a bulk loader:
  - createFileAttributes.sql: 10-column table (wider filepath and file_format than the Oracle counterpart) plus core.TableInfo registration
  - dropFileAttributes.sql: drops the table and its core.TableInfo row

Postgres translations vs the Oracle script: NEXTVAL('core.tableinfo_sq') for the sequence, no dual, localtimestamp for sysdate, NULL instead of '' for view_on_table_id/superclass_table_id, and no sqlplus exit.

This table intentionally diverges from Oracle: only the Postgres copy is populated going forward.