### PR TITLE
Add modification_date to the ApiDB variation tables

### DIFF
--- a/Main/lib/sql/apidbschema/Postgres/addModificationDateToVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/addModificationDateToVariationTables.sql
@@ -1,0 +1,39 @@
+-- Patch for databases created before modification_date was added to the
+-- variation tables. New installs get it from createVariationTables.sql; this
+-- script brings an existing instance to the same state and is idempotent, so it
+-- is safe to re-run.
+--
+-- Why: TuningManager detects change in tables declared as <externalDependency>
+-- (apiTuningManager.xml) by comparing max(modification_date) and count(*)
+-- against apidb.TuningMgrExternalDependency -- see
+-- TuningManager::ExternalTable::getTimestamp. Without the column those three
+-- dependencies cannot be tracked.
+--
+-- Existing rows: localtimestamp is not volatile, so Postgres applies the default
+-- without rewriting the table and every pre-existing row is stamped with the
+-- time this patch ran. That is the intended reading -- "last known change" --
+-- and it makes the first TuningManager pass after the patch see a new
+-- max(modification_date) and rebuild the dependent tuning tables once.
+
+ALTER TABLE ApiDB.VariationFeature
+  ADD COLUMN IF NOT EXISTS modification_date TIMESTAMP DEFAULT localtimestamp NOT NULL;
+
+ALTER TABLE ApiDB.VariationTranscriptProduct
+  ADD COLUMN IF NOT EXISTS modification_date TIMESTAMP DEFAULT localtimestamp NOT NULL;
+
+ALTER TABLE ApiDB.VariationEffect
+  ADD COLUMN IF NOT EXISTS modification_date TIMESTAMP DEFAULT localtimestamp NOT NULL;
+
+-- Keeps TuningManager's max(modification_date) off a full scan of these
+-- (multi-million-row) tables on every pass.
+CREATE INDEX IF NOT EXISTS variationfeature_moddate_ix
+  ON ApiDB.VariationFeature (modification_date);
+CREATE INDEX IF NOT EXISTS variationtranscriptproduct_md_ix
+  ON ApiDB.VariationTranscriptProduct (modification_date);
+CREATE INDEX IF NOT EXISTS variationeffect_moddate_ix
+  ON ApiDB.VariationEffect (modification_date);
+
+-- No trigger: the column default supplies modification_date for the only write
+-- pattern these tables see (delete by external_database_release_id + COPY
+-- reload). DEFAULT does not fire on UPDATE -- see the note in
+-- createVariationTables.sql if you ever need to update a row in place.

--- a/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+++ b/Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
@@ -34,6 +34,7 @@ CREATE TABLE ApiDB.VariationFeature (
   indel_minor_genomic_hgvs        VARCHAR(500),
   indel_frame_effect              VARCHAR(20),
   external_database_release_id    NUMERIC(10)   NOT NULL,
+  modification_date               TIMESTAMP     DEFAULT localtimestamp NOT NULL,
   PRIMARY KEY (sequence_source_id, location),
   FOREIGN KEY (external_database_release_id) REFERENCES sres.ExternalDatabaseRelease (external_database_release_id),
   UNIQUE (source_id)
@@ -43,6 +44,22 @@ GRANT SELECT ON ApiDB.VariationFeature TO gus_r;
 GRANT INSERT, UPDATE, DELETE ON ApiDB.VariationFeature TO gus_w;
 
 CREATE INDEX variationfeature_extdbrls_ix ON ApiDB.VariationFeature (external_database_release_id);
+
+-- modification_date is TuningManager's change-detection signal for these three
+-- tables (they are declared as <externalDependency> in apiTuningManager.xml, and
+-- TuningManager::ExternalTable compares max(modification_date) + count(*) against
+-- apidb.TuningMgrExternalDependency). The column default supplies it server-side
+-- for COPY and INSERT, so no loader has to remember to.
+--
+-- NOTE: DEFAULT does not fire on UPDATE. These tables are only ever written by
+-- delete-by-external_database_release_id + reload, so that is fine today. If you
+-- ever update a row in place, set modification_date = localtimestamp in the same
+-- statement, or attach apidb.trigger_fct_update_modification_date() (defined in
+-- createReportCache.sql) as a BEFORE UPDATE trigger -- otherwise the dependent
+-- tuning tables go stale silently, with no error anywhere.
+--
+-- The index keeps TuningManager's max(modification_date) off a full scan.
+CREATE INDEX variationfeature_moddate_ix ON ApiDB.VariationFeature (modification_date);
 
 ---------ApiDB.VariationTranscriptProduct ------------------
 ------------------------------------------------------------
@@ -60,6 +77,7 @@ CREATE TABLE ApiDB.VariationTranscriptProduct (
   matches_ref_codon                   NUMERIC(1),
   matches_ref_product                 NUMERIC(1),
   hgvs_p                              VARCHAR(500),
+  modification_date                   TIMESTAMP     DEFAULT localtimestamp NOT NULL,
   FOREIGN KEY (sequence_source_id, location) REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
   FOREIGN KEY (na_feature_id) REFERENCES dots.NaFeatureImp (na_feature_id)
 );
@@ -69,6 +87,7 @@ GRANT INSERT, UPDATE, DELETE ON ApiDB.VariationTranscriptProduct TO gus_w;
 
 CREATE INDEX variationtranscriptproduct_loc_ix ON ApiDB.VariationTranscriptProduct (sequence_source_id, location);
 CREATE INDEX variationtranscriptproduct_naf_ix ON ApiDB.VariationTranscriptProduct (na_feature_id);
+CREATE INDEX variationtranscriptproduct_md_ix ON ApiDB.VariationTranscriptProduct (modification_date);
 
 ---------ApiDB.VariationEffect -----------------------------
 ------------------------------------------------------------
@@ -82,6 +101,7 @@ CREATE TABLE ApiDB.VariationEffect (
   effect               VARCHAR(60),
   hgvs_c               VARCHAR(500),
   source               VARCHAR(20),
+  modification_date    TIMESTAMP     DEFAULT localtimestamp NOT NULL,
   FOREIGN KEY (sequence_source_id, location) REFERENCES ApiDB.VariationFeature (sequence_source_id, location) ON DELETE CASCADE,
   FOREIGN KEY (na_feature_id) REFERENCES dots.NaFeatureImp (na_feature_id)
 );
@@ -92,4 +112,5 @@ GRANT INSERT, UPDATE, DELETE ON ApiDB.VariationEffect TO gus_w;
 
 CREATE INDEX variationeffect_loc_ix ON ApiDB.VariationEffect (sequence_source_id, location);
 CREATE INDEX variationeffect_naf_ix ON ApiDB.VariationEffect (na_feature_id);
+CREATE INDEX variationeffect_moddate_ix ON ApiDB.VariationEffect (modification_date);
 


### PR DESCRIPTION
## Why

`apiTuningManager.xml` declares all three variation tables as `<externalDependency>`:

```xml
<externalDependency name="apidb.VariationFeature"/>
<externalDependency name="apidb.VariationTranscriptProduct"/>
<externalDependency name="apidb.VariationEffect"/>
```

`TuningManager::ExternalTable::getTimestamp` decides whether such a table has changed by comparing `max(modification_date)` and `count(*)` against `apidb.TuningMgrExternalDependency`. None of the three had a `modification_date` column, so tuningManager threw warnings on these dependencies and had no way to tell whether the tables had changed.

## What

- `modification_date TIMESTAMP DEFAULT localtimestamp NOT NULL` on `VariationFeature`, `VariationTranscriptProduct` and `VariationEffect`.
- An index on `modification_date` for each, so TuningManager's `max(modification_date)` does not seq-scan tables that run to millions of rows.
- `addModificationDateToVariationTables.sql` to patch existing instances. Idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), and out-of-band rather than in `installApidbSchema`'s `@create` list, following `addConstraintsAndIndexesToSnpTables.sql`.

## Notes for review

- **Why the default rather than the loader writing it.** `COPY` cannot call `now()` in the data stream, so a loader-side value would be the loader host's clock and would have to be re-remembered by every future writer. The column default puts it server-side and makes it unforgettable. `InsertVariationFeatures` therefore needs no change; its `\copy` column lists simply omit the column. (Documented on the ApiCommonData side so nobody "fixes" it.)
- **No trigger.** `DEFAULT` does not fire on `UPDATE`. These tables are only ever written by delete-by-`external_database_release_id` + COPY reload, so the default is sufficient today, and a per-row `BEFORE` trigger is a real cost on a genome-wide reload. The DDL comment records the caveat and points at `apidb.trigger_fct_update_modification_date()` for whoever first needs an in-place update. Note that tuningManager will create that trigger itself under `-doUpdate`.
- **Existing rows.** `localtimestamp` is non-volatile, so Postgres applies the default without rewriting the table and stamps pre-existing rows with the patch time. The first tuningManager pass after the patch therefore sees a new `max(modification_date)` and rebuilds the dependent tuning tables once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)